### PR TITLE
Persist provider choice across app

### DIFF
--- a/src/components/NodeEnhancementModal.jsx
+++ b/src/components/NodeEnhancementModal.jsx
@@ -40,7 +40,8 @@ const NodeEnhancementModal = ({ node, onNodeUpdate, trigger }) => {
         const providers = await promptingEngine.getAvailableProviders();
         setAvailableProviders(providers);
         if (providers.length > 0) {
-          const activeProvider = providers.find(p => p.isActive) || providers[0];
+          const storedId = sessionStorage.getItem('active_provider');
+          const activeProvider = providers.find(p => p.providerId === storedId) || providers.find(p => p.isActive) || providers[0];
           setSelectedProvider(activeProvider.providerId);
           
           // Use smaller model for node enhancement by default

--- a/src/components/ProviderSettings.jsx
+++ b/src/components/ProviderSettings.jsx
@@ -15,8 +15,8 @@ const defaultProviders = [
     providerId: 'openai',
     name: 'OpenAI',
     baseURL: 'https://api.openai.com/v1',
-    models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4', 'o1-preview', 'o1-mini'],
-    defaultModel: 'gpt-4o',
+    models: ['venice-uncensored', 'mistral-31-24b', 'llama-3.2-3b'],
+    defaultModel: 'venice-uncensored',
     apiKey: '',
     isActive: true,
     description: 'Original ChatGPT models with highest quality reasoning'
@@ -25,8 +25,14 @@ const defaultProviders = [
     providerId: 'openrouter',
     name: 'OpenRouter',
     baseURL: 'https://openrouter.ai/api/v1',
-    models: ['openai/gpt-4o', 'anthropic/claude-3.5-sonnet', 'google/gemini-2.0-flash-exp', 'meta-llama/llama-3.1-405b-instruct'],
-    defaultModel: 'openai/gpt-4o',
+    models: [
+      'qwen/qwen3-235b-a22b-07-25:free',
+      'moonshotai/kimi-k2:free',
+      'cognitivecomputations/dolphin-mistral-24b-venice-edition:free',
+      'qwen/qwen3-235b-a22b:free',
+      'deepseek/deepseek-chat-v3-0324:free',
+    ],
+    defaultModel: 'qwen/qwen3-235b-a22b-07-25:free',
     apiKey: '',
     isActive: false,
     description: 'Access to multiple AI models through one API'
@@ -35,8 +41,8 @@ const defaultProviders = [
     providerId: 'venice',
     name: 'Venice AI',
     baseURL: 'https://api.venice.ai/api/v1',
-    models: ['gpt-4o', 'gpt-4o-mini', 'claude-3.5-sonnet'],
-    defaultModel: 'gpt-4o',
+    models: ['venice-uncensored', 'mistral-31-24b', 'llama-3.2-3b'],
+    defaultModel: 'venice-uncensored',
     apiKey: '',
     isActive: false,
     description: 'Privacy-focused AI inference with no data retention'

--- a/src/components/ProviderSetup.jsx
+++ b/src/components/ProviderSetup.jsx
@@ -92,11 +92,17 @@ const ProviderSetup = ({ userId, onComplete }) => {
           SecureKeyManager.storeApiKey(providerId, key);
         }
       });
+      providers.forEach(p => {
+        if (p.baseURL) {
+          sessionStorage.setItem(`base_url_${p.providerId}`, p.baseURL);
+        }
+      });
 
       // Store the active provider's API key in session storage for immediate use
       const activeProvider = providers.find(p => p.isActive);
       if (activeProvider && apiKeys[activeProvider.providerId]) {
         sessionStorage.setItem('openai_api_key', apiKeys[activeProvider.providerId]);
+        sessionStorage.setItem('active_provider', activeProvider.providerId);
       }
       
       toast({ title: "Success", description: "Provider settings saved." });

--- a/src/components/TextToWorkflow.jsx
+++ b/src/components/TextToWorkflow.jsx
@@ -26,7 +26,8 @@ const TextToWorkflow = ({ onWorkflowGenerated, apiKey }) => {
         const providers = await promptingEngine.getAvailableProviders();
         setAvailableProviders(providers);
         if (providers.length > 0) {
-          const activeProvider = providers.find(p => p.isActive) || providers[0];
+          const storedId = sessionStorage.getItem('active_provider');
+          const activeProvider = providers.find(p => p.providerId === storedId) || providers.find(p => p.isActive) || providers[0];
           setSelectedProvider(activeProvider.providerId);
           setSelectedModel(activeProvider.models[0]);
         }

--- a/src/lib/WorkflowExecutionEngine.js
+++ b/src/lib/WorkflowExecutionEngine.js
@@ -1,4 +1,5 @@
 import PromptingEngine from './promptingEngine.js';
+import { SecureKeyManager } from './security.js';
 
 class WorkflowExecutionEngine {
   constructor(userId, toast) {
@@ -13,9 +14,9 @@ class WorkflowExecutionEngine {
     }
 
     const providers = await this.engine.getAvailableProviders();
-    const activeProvider =
-      providers.find(p => sessionStorage.getItem(`${p.providerId}_api_key`)) || providers[0];
-    const apiKey = sessionStorage.getItem(`${activeProvider.providerId}_api_key`);
+    const activeId = sessionStorage.getItem('active_provider') || providers[0].providerId;
+    const activeProvider = providers.find(p => p.providerId === activeId) || providers[0];
+    const apiKey = SecureKeyManager.getApiKey(activeProvider.providerId);
     if (!apiKey) {
       throw new Error('No active provider configured. Please set up your AI providers in settings.');
     }

--- a/src/lib/promptingEngine.js
+++ b/src/lib/promptingEngine.js
@@ -302,7 +302,11 @@ Enhanced Content:`;
 
   // Helper: Get available providers for prompting
   async getAvailableProviders() {
-    return this.providers;
+    return this.providers.map(p => ({
+      ...p,
+      baseURL: sessionStorage.getItem(`base_url_${p.providerId}`) || p.baseURL,
+      isActive: sessionStorage.getItem('active_provider') === p.providerId,
+    }));
   }
 
   // Helper: Get recommended models for different prompting tasks


### PR DESCRIPTION
## Summary
- update provider models for OpenRouter and Venice
- load provider settings from sessionStorage
- store API keys and base URLs on save
- default AI provider is picked from saved choice in sidebar and modals
- respect active provider when executing workflows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fc967f610832d97a739f788b18167